### PR TITLE
fix: GEMINIモデル名をgemini-1.5-flashに変更

### DIFF
--- a/chat-app/app/page.tsx
+++ b/chat-app/app/page.tsx
@@ -36,7 +36,7 @@ export default function Home() {
 
     try {
       const genAI = new GoogleGenerativeAI(GEMINI_API_KEY);
-      const model = genAI.getGenerativeModel({ model: 'gemini-2.0-flash-exp' });
+      const model = genAI.getGenerativeModel({ model: 'gemini-1.5-flash' });
 
       // 会話履歴を作成
       const chatHistory = messages.map((msg) => ({


### PR DESCRIPTION
## 概要
issue #5 で報告された404エラーを修正しました。

## 変更内容
- `chat-app/app/page.tsx` の39行目のGEMINIモデル名を変更
- `gemini-2.0-flash-exp` → `gemini-1.5-flash`

## 修正理由
- `gemini-2.0-flash-exp` は v1beta API で利用できず、404エラーが発生していた
- `gemini-1.5-flash` は安定して利用可能

## 期待される結果
- 404エラーが解消される
- チャット機能が正常に動作する

Closes #5

🤖 Generated with [Claude Code](https://claude.com/claude-code)