### PR TITLE
docs: Docker ローカル起動方法の追記とテスト (#13)

### DIFF
--- a/chat-app/README.md
+++ b/chat-app/README.md
@@ -43,6 +43,34 @@ npm run dev
 
 http://localhost:3000 でアプリケーションが起動します。
 
+## Docker でのローカル起動
+
+Docker を使用してローカル環境でアプリケーションを起動できます。
+
+### 1. Docker イメージのビルド
+
+```bash
+docker build -t chat-app .
+```
+
+### 2. コンテナの起動
+
+GEMINI_API_KEY を環境変数として渡してコンテナを起動します：
+
+```bash
+docker run -p 8080:8080 -e GEMINI_API_KEY=your_api_key_here chat-app
+```
+
+### 3. アクセス
+
+http://localhost:8080 でアプリケーションにアクセスできます。
+
+### 注意事項
+
+- `your_api_key_here` の部分を実際の GEMINI API キーに置き換えてください
+- ポート 8080 が他のプロセスで使用されていないことを確認してください
+- コンテナを停止するには `Ctrl + C` を押してください
+
 ## Cloud Run へのデプロイ
 
 ### 前提条件


### PR DESCRIPTION
## 概要
issue #13 で依頼された Docker でのローカル起動方法を README.md に追記し、実際にテストを実施したワン。

## 変更内容
### README.md への追記
- ✅ Docker でのローカル起動セクションを追加
- ✅ docker build コマンドの説明
- ✅ docker run コマンドと GEMINI_API_KEY 環境変数の渡し方
- ✅ アクセス URL（http://localhost:8080）
- ✅ 注意事項（API キーの置き換え、ポート確認、停止方法）

## Docker テスト結果
### ビルドテスト
✅ Docker イメージのビルドが成功
- Node.js 20 Alpine ベースイメージを使用
- 依存関係のインストール完了
- Next.js のビルドが正常に完了
- standalone モードでビルド成功

### 起動テスト
✅ コンテナが正常に起動
- ポート 8080 でリッスン開始
- Next.js サーバーが 39ms で起動完了
- 環境変数 GEMINI_API_KEY の受け渡し確認

### 動作テスト
✅ HTTP アクセス確認
- http://localhost:8080 にアクセス可能
- チャット UI が正常に表示
- HTML レスポンスが正常に返却

## 確認方法
以下のコマンドで確認できるワン：
```bash
cd chat-app
docker build -t chat-app .
docker run -p 8080:8080 -e GEMINI_API_KEY=your_api_key_here chat-app
# http://localhost:8080 にアクセス
```

## 関連 issue
Closes #13

🤖 Generated with [Claude Code](https://claude.com/claude-code)