### PR TITLE
feat: Grounding with Google Search を統合 (#17)

### DIFF
--- a/chat-app/app/page.tsx
+++ b/chat-app/app/page.tsx
@@ -5,6 +5,7 @@ import { useState } from 'react';
 interface Message {
   role: 'user' | 'assistant';
   content: string;
+  citations?: string[];
 }
 
 export default function Home() {
@@ -36,6 +37,7 @@ export default function Home() {
         const assistantMessage: Message = {
           role: 'assistant',
           content: data.response,
+          citations: data.citations,
         };
         setMessages((prev) => [...prev, assistantMessage]);
       } else {
@@ -86,6 +88,25 @@ export default function Home() {
                 }`}
               >
                 <p className="whitespace-pre-wrap break-words">{message.content}</p>
+                {message.citations && message.citations.length > 0 && (
+                  <div className="mt-2 border-t pt-2">
+                    <p className="text-xs text-gray-500 mb-1">参考サイト:</p>
+                    <ul className="space-y-1">
+                      {message.citations.map((citation, idx) => (
+                        <li key={idx}>
+                          <a
+                            href={citation}
+                            target="_blank"
+                            rel="noopener noreferrer"
+                            className="text-xs text-blue-600 hover:underline break-all"
+                          >
+                            {citation}
+                          </a>
+                        </li>
+                      ))}
+                    </ul>
+                  </div>
+                )}
               </div>
             </div>
           ))}


### PR DESCRIPTION
## 概要
issue #17 で依頼された Grounding with Google Search を統合し、最新情報を活用した回答を提供できるようにしたワン。

## 実装内容
### API Routes の修正（route.ts）
✅ Grounding with Google Search を統合
- `getGenerativeModel` の `tools` に `googleSearch` を追加
- グラウンディングメタデータから引用元URLを取得
- レスポンスに `citations` フィールドを追加

### フロントエンドの修正（page.tsx）
✅ 引用元URL表示機能を追加
- `Message` インターフェースに `citations` フィールドを追加
- メッセージ表示部分に「参考サイト」セクションを追加
- 引用元URLをクリック可能なリンクとして表示

## 技術的な詳細
```typescript
// API Routes
const model = genAI.getGenerativeModel({
  model: 'gemini-2.5-flash',
  tools: [{ googleSearch: {} }],
});

// グラウンディングメタデータから引用元URLを取得
const groundingMetadata = response.candidates?.[0]?.groundingMetadata;
const groundingChunks = groundingMetadata?.groundingChunks;
```

## 期待される効果
✅ 最新情報に基づいた回答が可能になる
✅ 回答の信頼性が向上する（引用元URL表示）
✅ ユーザー体験の向上

## 参考資料
- https://ai.google.dev/gemini-api/docs/google-search

## 関連 issue
Closes #17

🤖 Generated with [Claude Code](https://claude.com/claude-code)