### PR TITLE
feat: tmux ユーザーオプションでペインを参照するように修正 (#24)

### DIFF
--- a/setup.sh
+++ b/setup.sh
@@ -124,6 +124,9 @@ for i in {0..3}; do
     # エージェント役割を環境変数として設定
     tmux send-keys -t "$PANE_ID" "export AGENT_ROLE='${TITLE}'" C-m
 
+    # tmux ユーザーオプションとして役割を設定
+    tmux set-option -p -t "$PANE_ID" @agent_role "${TITLE}"
+
     # カラープロンプト設定
     if [ $i -eq 0 ]; then
         # 桃太郎: 赤色
@@ -147,6 +150,11 @@ log_info "👑 mainセッション作成開始..."
 tmux new-session -d -s main
 tmux send-keys -t main "cd $(pwd)" C-m
 tmux send-keys -t main "export AGENT_ROLE='おじいさん'" C-m
+
+# tmux ユーザーオプションとして役割を設定
+MAIN_PANE_ID=$(tmux list-panes -t main -F "#{pane_id}")
+tmux set-option -p -t "$MAIN_PANE_ID" @agent_role "おじいさん"
+
 set_color_prompt "main" "おじいさん" "35"
 tmux send-keys -t main "echo '=== おじいさん セッション ==='" C-m
 tmux send-keys -t main "echo '役割: おじいさん'" C-m


### PR DESCRIPTION
## 概要
pane ID ではなく tmux のユーザーオプション（`@agent_role`）を使ってペインを参照するように修正しました。

## 背景
pane ID は動的に変化する可能性があるため、より安定した参照が必要でした。

## 変更内容

### setup.sh
- 各ペインに `tmux set-option -p -t "$PANE_ID" @agent_role "${TITLE}"` でユーザーオプションを設定
- agentsセッションの4ペイン（桃太郎、お供の犬、お供の猿、お供の雉）に対応
- mainセッション（おじいさん）にも対応

### agent-send.sh
- `get_agent_target()` 関数を全面改修
  - `tmux list-panes -a -F "#{pane_id} #{@agent_role}"` で全ペインのユーザーオプションを取得
  - 該当する役割名を持つペインの pane_id を返す
- `check_target()` 関数を修正
  - pane_id の有効性を `tmux display-message` で確認
- `show_agents()` 関数を修正
  - 全エージェントに対して統一的に `get_agent_target()` を使用

## 効果
- pane ID が変化しても役割名で安定してペインを参照可能
- base-index や pane-base-index への依存を完全に排除
- コードがよりシンプルで保守しやすくなりました

## テスト計画
- [ ] setup.sh を実行して環境を構築
- [ ] `tmux list-panes -a -F "#{pane_id} #{@agent_role}"` でユーザーオプションが正しく設定されているか確認
- [ ] `./agent-send.sh --list` でエージェント一覧が正しく表示されるか確認
- [ ] `./agent-send.sh [エージェント名] "[メッセージ]"` でメッセージ送信が正しく動作するか確認

Closes #24

🤖 Generated with [Claude Code](https://claude.com/claude-code)