### PR TITLE
chore: 旧 chat-app への参照を削除し、ドキュメントを更新

### DIFF
--- a/instructions/ojiisan.md
+++ b/instructions/ojiisan.md
@@ -23,7 +23,7 @@
 
 **良い例:**
 ```bash
-./agent-send.sh 桃太郎 "chat-app/ 用の Dockerfile を作成してほしい"
+./agent-send.sh 桃太郎 "chat-backend/ 用の API エンドポイントを追加してほしい"
 ```
 
 **悪い例:**


### PR DESCRIPTION
## 概要
issue #36 の対応として、旧 chat-app への参照を削除し、ドキュメントと実際のプロジェクト構成を一致させたウキー。

## 変更内容
- **instructions/ojiisan.md の例文を更新**: `chat-app/` → `chat-backend/` に変更
- **ローカル環境の chat-app ディレクトリを削除**: git 管理外のビルド成果物（.next, node_modules など）を削除

## 背景
- issue #29 でプロジェクト構成が変更され、chat-app は chat-frontend と chat-backend に分離された
- 旧 chat-app ディレクトリには .next や node_modules などのビルド成果物のみが残存していた
- issue #15, #16 は旧 chat-app を前提としており、現在の構成では対応不要

## PR マージ後の作業
このPRがマージされた後、以下の issue をクローズする予定ウキー：
- issue #15: chat-app の npm 開発サーバー起動と動作確認
- issue #16: chat-app の .env.example に GEMINI_API_KEY を追加
- issue #36: 旧 chat-app の整理

## 関連 issue
Closes #36
Refs #15, #16

🐵 お供の猿が作成したウキー