### PR TITLE
fix: ドキュメント内の Google API Key をプレースホルダーに置き換え (#56)

### DIFF
--- a/docs/frontend-backend-separation-plan.md
+++ b/docs/frontend-backend-separation-plan.md
@@ -166,7 +166,7 @@ ALLOWED_ORIGINS=http://localhost:3000
 
 `chat-backend/.env.local`:
 ```
-GEMINI_API_KEY=AIzaSyCrIltaWWJZNwS0djqhdIn5xNRW-_ZeZbg
+GEMINI_API_KEY=your_gemini_api_key_here
 ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
 ```
 
@@ -586,7 +586,7 @@ rm -rf chat-app-legacy
 
 10. **`chat-backend/.env.local`**
     ```
-    GEMINI_API_KEY=AIzaSyCrIltaWWJZNwS0djqhdIn5xNRW-_ZeZbg
+    GEMINI_API_KEY=your_gemini_api_key_here
     ALLOWED_ORIGINS=http://localhost:3000,http://localhost:8080
     ```
 
@@ -712,7 +712,7 @@ docker system prune -f
 
 ## Notes
 
-- GEMINI_API_KEY は `.env.local` に既に設定済み（`AIzaSyCrIltaWWJZNwS0djqhdIn5xNRW-_ZeZbg`）
+- GEMINI_API_KEY は `.env.local` に設定が必要（実際の API Key を設定してください）
 - Google Cloud Project ID は実際の値に置き換える必要あり
 - 既存の `chat-app/` は `chat-app-legacy/` として保持し、動作確認後に削除
 - フロントエンドはSSRを保持するため、完全な静的エクスポートではない


### PR DESCRIPTION
## 🚨 緊急対応

ドキュメント内に記載されていた Google API Key をプレースホルダーに置き換えました。

## 変更内容

`docs/frontend-backend-separation-plan.md` 内の以下の箇所を修正：

1. **169行目**: `.env.local` の例
   - 変更前: `GEMINI_API_KEY=AIzaSyCrIltaWWJZNwS0djqhdIn5xNRW-_ZeZbg`
   - 変更後: `GEMINI_API_KEY=your_gemini_api_key_here`

2. **589行目**: 環境変数ファイルの例
   - 変更前: `GEMINI_API_KEY=AIzaSyCrIltaWWJZNwS0djqhdIn5xNRW-_ZeZbg`
   - 変更後: `GEMINI_API_KEY=your_gemini_api_key_here`

3. **715行目**: Notes セクションのコメント
   - 変更前: `GEMINI_API_KEY は .env.local に既に設定済み（AIzaSyCrIltaWWJZNwS0djqhdIn5xNRW-_ZeZbg）`
   - 変更後: `GEMINI_API_KEY は .env.local に設定が必要（実際の API Key を設定してください）`

## セキュリティ対応

- ✅ 全ての API Key をプレースホルダーに置き換え完了
- ⚠️ おじいさんに確認が必要な項目:
  - この API Key を無効化すべきか
  - Git 履歴から API Key を削除する必要があるか

## 関連 issue

Closes #56

🤖 Generated with [Claude Code](https://claude.com/claude-code)