### PR TITLE
feat: worktree のディレクトリ作成場所のルールを明記

### DIFF
--- a/instructions/otomo.md
+++ b/instructions/otomo.md
@@ -42,6 +42,28 @@
 #### 2. ブランチ・worktree を作成する
 issue を元にブランチと worktree を作成し、worktree 内で作業を行う。
 
+**worktree のディレクトリ作成場所（重要）:**
+- **必ず**プロジェクトルート直下の `worktrees/` ディレクトリ配下に作成すること
+- ディレクトリ構造：
+  ```
+  /Users/kenji.nakagaki/git/aichat-pbcc/
+  ├── worktrees/
+  │   ├── feature-issue-XX/
+  │   └── feature-issue-YY/
+  ```
+
+**作成コマンド例：**
+```bash
+# メインリポジトリで実行
+cd /Users/kenji.nakagaki/git/aichat-pbcc
+git worktree add worktrees/feature-issue-XX -b feature/issue-XX-description
+```
+
+**注意事項：**
+- worktree 名は `feature-issue-XX` の形式を推奨（XX は issue 番号）
+- ブランチ名は `feature/issue-XX-description` の形式を推奨
+- 作業は必ず worktree 内で行うこと
+
 #### 3. 作業を実行する
 worktree 内で指示された作業を行い、コミットする。
 
@@ -65,6 +87,11 @@ worktree 内で指示された作業を行い、コミットする。
 
 1. プルリクエストをno-ffマージ
 2. worktree を削除
+   ```bash
+   # メインリポジトリから実行
+   cd /Users/kenji.nakagaki/git/aichat-pbcc
+   git worktree remove worktrees/feature-issue-XX
+   ```
 3. ブランチを削除
 4. **メインリポジトリを最新化**（重要）
    ```bash


### PR DESCRIPTION
## Summary
- worktree のディレクトリ作成場所のルールを instructions/otomo.md に明記
- プロジェクトルート直下の worktrees/ ディレクトリ配下に統一

## 変更内容

### instructions/otomo.md
- **worktree のディレクトリ作成場所** セクションを追加
  - プロジェクトルート直下の `worktrees/` ディレクトリ配下に作成するルールを明記
  - ディレクトリ構造の図を追加
  - 作成コマンド例を追加
  - worktree 名とブランチ名の推奨形式を追加

- **worktree 削除コマンド** を追加
  - マージ・クリーンアップセクションに具体的なコマンドを追加
  - `git worktree remove worktrees/feature-issue-XX` の形式を明記

## 期待される効果
- worktree 作成場所が統一される
- お供間での混乱が減る
- プロジェクト管理がしやすくなる

## Test plan
- [ ] instructions/otomo.md に worktree 作成場所のルールが明記されていることを確認
- [ ] ディレクトリ構造と作成コマンド例が正しいことを確認
- [ ] worktree 削除コマンドが正しいことを確認

Closes #69

🤖 Generated with [Claude Code](https://claude.com/claude-code)