### PR TITLE
fix: devcontainer の Claude CLI インストール URL を修正

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -46,7 +46,7 @@ RUN ARCH=$(dpkg --print-architecture) && \
     rm gitleaks_8.18.1_linux_${GITLEAKS_ARCH}.tar.gz
 
 # Claude Code CLI のインストール
-RUN curl -fsSL https://raw.githubusercontent.com/anthropics/claude-code/main/install.sh -o /tmp/install-claude.sh \
+RUN curl -fsSL https://claude.ai/install.sh -o /tmp/install-claude.sh \
     && chmod +x /tmp/install-claude.sh \
     && bash /tmp/install-claude.sh || echo "⚠️  Claude CLI のインストールをスキップ" \
     && rm -f /tmp/install-claude.sh


### PR DESCRIPTION
## 概要
devcontainer 内で Claude CLI が使用できない問題を修正。

## 問題
`.devcontainer/Dockerfile` の Claude CLI インストールスクリプト URL が 404 エラーになっていた。

## 修正内容
- URL を `https://raw.githubusercontent.com/anthropics/claude-code/main/install.sh` から `https://claude.ai/install.sh` に変更
- 旧 URL は 404 エラーだったため、Claude CLI がインストールされていなかった

## 影響
devcontainer をリビルドすることで、claude コマンドが正常に使用できるようになる。

## 関連 issue
Closes #91

## テスト方法
1. devcontainer をリビルド（`Dev Containers: Rebuild Container`）
2. コンテナ内で `claude --version` を実行して動作確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)