### PR TITLE
fix: devcontainerのユーザー設定をnodeに変更 (#99)

### DIFF
--- a/.devcontainer/Dockerfile
+++ b/.devcontainer/Dockerfile
@@ -51,8 +51,8 @@ RUN curl -fsSL https://claude.ai/install.sh -o /tmp/install-claude.sh \
     && bash /tmp/install-claude.sh || echo "⚠️  Claude CLI のインストールをスキップ" \
     && rm -f /tmp/install-claude.sh
 
-# PATH に追加
-ENV PATH="/home/vscode/.local/bin:${PATH}"
+# PATH に追加（nodeユーザーのパスを使用）
+ENV PATH="/home/node/.local/bin:${PATH}"
 
 # 作業ディレクトリの設定
 WORKDIR /workspace
@@ -63,5 +63,5 @@ RUN touch /.devcontainer_marker
 # デフォルトシェルを bash に設定
 ENV SHELL=/bin/bash
 
-# vscode ユーザーに切り替え
-USER vscode
+# node ユーザーに切り替え（ベースイメージのデフォルトユーザー）
+USER node

--- a/.devcontainer/devcontainer.json
+++ b/.devcontainer/devcontainer.json
@@ -28,9 +28,9 @@
   },
   "forwardPorts": [3000, 8080, 8081],
   "postCreateCommand": "npm install -g pnpm && echo 'Dev container ready!'",
-  "remoteUser": "vscode",
+  "remoteUser": "node",
   "mounts": [
-    "source=${localEnv:HOME}/.claude,target=/home/vscode/.claude,type=bind,consistency=cached"
+    "source=${localEnv:HOME}/.claude,target=/home/node/.claude,type=bind,consistency=cached"
   ],
   "remoteEnv": {
     "AGENT_ROLE": "${localEnv:AGENT_ROLE}"


### PR DESCRIPTION
## 概要
devcontainer起動時の「unable to find user vscode: no matching entries in passwd file」エラーを修正しました。

## 問題の原因
- ベースイメージ `mcr.microsoft.com/devcontainers/javascript-node:20-bookworm` のデフォルトユーザーは `node` です
- しかし、Dockerfileで `USER vscode` に切り替え、devcontainer.jsonで `remoteUser: vscode` を指定していました
- `vscode` ユーザーがシステムに存在しないため、エラーが発生していました

## 修正内容
- Dockerfileの `USER` を `vscode` から `node` に変更
- devcontainer.jsonの `remoteUser` を `vscode` から `node` に変更
- PATH とマウントパスも `/home/node` に統一

## 動作確認
- [ ] devcontainerが正常に起動することを確認
- [ ] Claude CLI が正常に動作することを確認
- [ ] AGENT_ROLE 環境変数が正しく設定されることを確認

Fixes #99

🤖 Generated with [Claude Code](https://claude.com/claude-code)