### PR TITLE
chore: next-env.d.tsをgit管理から除外

### DIFF
--- a/chat-backend/.gitignore
+++ b/chat-backend/.gitignore
@@ -31,3 +31,6 @@ Thumbs.db
 # ログ
 *.log
 logs/
+
+# Next.js auto-generated
+next-env.d.ts

--- a/chat-backend/next-env.d.ts
+++ b/chat-backend/next-env.d.ts
@@ -1,6 +1,0 @@
-/// <reference types="next" />
-/// <reference types="next/image-types/global" />
-import "./.next/types/routes.d.ts";
-
-// NOTE: This file should not be edited
-// see https://nextjs.org/docs/app/api-reference/config/typescript for more information.


### PR DESCRIPTION
## Summary
- `chat-backend/.gitignore` に `next-env.d.ts` を追加
- Next.jsが自動生成するファイルのため、git管理対象から除外

## Test plan
- [ ] `chat-backend/next-env.d.ts` がgit管理対象外になっていることを確認

🤖 Generated with [Claude Code](https://claude.com/claude-code)